### PR TITLE
Use correct architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,6 +6,6 @@ sentence=Allow to reset an arduino board from the sketch
 paragraph=
 category=Device Control
 url=https://github.com/HackerInside0/Arduino_SoftwareReset.git
-architectures=AVR
+architectures=avr
 dot_a_linkage=true
 includes=SoftwareReset.h


### PR DESCRIPTION
Use of incorrect `architectures` value causes the warning:
```
WARNING: library Arduino_SoftwareReset claims to run on [AVR] architecture(s) and may be incompatible with your current board which runs on [avr] architecture(s).
```
on compilation.