### PR TITLE
fix: remove `.a` linkage flag

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,4 @@ paragraph=
 category=Device Control
 url=https://github.com/qub1750ul/Arduino_SoftwareReset
 architectures=avr
-dot_a_linkage=true
 includes=SoftwareReset.h


### PR DESCRIPTION
This is a single header implementation. It does not need to compile separately from the sketch code, and does not link for simple Arduino Uno projects.